### PR TITLE
New route configuration without MS name in uri

### DIFF
--- a/charts/api-gateway/config/application.yaml
+++ b/charts/api-gateway/config/application.yaml
@@ -15,35 +15,37 @@ spring:
   cloud:
     gateway:
       routes:
-        - id: alc_route
+        - id: alc_route-GET
           predicates:
-            - Path=/alc-collect/**
+            - Path=/api/v1/riskLimits
+            - Method=GET
           uri: https://{{ required "ALC collect application service name has to be defined in routes.alcCollect.serviceName" .Values.routes.alcCollect.serviceName }}:{{ required "ALC collect application port number has to be defined in routes.alcCollect.servicePortNumber" .Values.routes.alcCollect.servicePortNumber }}
           filters:
-            - StripPrefix=1
             - TokenRelay
             - SaveSession
-        - id: auth-limit-control_route
+            
+        - id: auth-limit-control_route-POST
           predicates:
-            - Path=/auth-limit-control/**
+            - Path=/api/authLimitControl/{messageType}
+            - Method=POST
           uri: https://{{ required "Auth limit control application service name has to be defined in routes.authLimitControl.serviceName" .Values.routes.authLimitControl.serviceName }}:{{ required "Auth limit control application port number has to be defined in routes.authLimitControl.servicePortNumber" .Values.routes.authLimitControl.servicePortNumber }}
           filters:
-            - StripPrefix=1
             - TokenRelay
             - SaveSession
-        - id: person-structure-ms_route
+            
+        - id: person-structure-ms_route-POST
           predicates:
-            - Path=/person-structure/**
+            - Path=/api/v1/riskLimits
+            - Method=POST
           uri: https://{{ required "Person structure application service name has to be defined in routes.personStructure.serviceName" .Values.routes.personStructure.serviceName }}:{{ required "Person structure application port number has to be defined in routes.personStructure.servicePortNumber" .Values.routes.personStructure.servicePortNumber }}
           filters:
-            - StripPrefix=1
             - TokenRelay
             - SaveSession
+            
         - id: person-registry-ms_route
           predicates:
-            - Path=/person-registry/**
+            - Path=/api/v1/personRegistry/**
           uri: https://{{ required "Person registry application service name has to be defined in routes.personRegistry.serviceName" .Values.routes.personRegistry.serviceName }}:{{ required "Person structure application port number has to be defined in routes.personRegistry.servicePortNumber" .Values.routes.personRegistry.servicePortNumber }}
           filters:
-            - StripPrefix=1
             - TokenRelay
             - SaveSession


### PR DESCRIPTION
Izmijenjene su rute sukladno odluci da se iz imena URI-a makne ime samog mikroservisa.

Trenutno smo dosta sareni sa strukturom ruta (dogovorili smo da ce svi imati oblik /api/v1/resurs). 

Prije spajanja ovih izmjena ce trebati pripaziti na sljedeće rute/msove i evenutalno promijeniti:

auth-limit-control -> trenutno je /api/RESURS umjesto /api/v1/RESURS
person-registry -> trenutno je /api/v1/personRegistry/RESURS (cini mi se da bi trebalo biti /api/v1/RESURS). U tom slucaju ce se morati eksplicitno pobrojati svi endpointi sa tog servisa

Svakako bi bilo dobro jos jednom provjeriti sa Markom V./Nikolom N. jel sve ok.
U slucaju da ce se nesto morati editirati po PR-u, vrlo vjerojatno necete imati prava s obzirom da se radi o mom privatnom forku. U tom slucaju preporucam uzimanje ovih izmjena i prilagodba direktno u originalnom repozitoriju sa vestigo-tech korisnikom.
Podatke za spajanje s tim korisnikom je Marija Lj. zapisala negdje u keepass pa nju pingajte za detalje.